### PR TITLE
chore(blockifier): add with_attr error message

### DIFF
--- a/crates/blockifier/feature_contracts/cairo0/compiled/test_contract_compiled.json
+++ b/crates/blockifier/feature_contracts/cairo0/compiled/test_contract_compiled.json
@@ -792,7 +792,26 @@
         "L1_HANDLER": []
     },
     "program": {
-        "attributes": [],
+        "attributes": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__",
+                    "__main__.fail"
+                ],
+                "end_pc": 1186,
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 95,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "name": "error_message",
+                "start_pc": 1182,
+                "value": "You shall not pass!"
+            }
+        ],
         "builtins": [
             "pedersen",
             "range_check",

--- a/crates/blockifier/feature_contracts/cairo0/test_contract.cairo
+++ b/crates/blockifier/feature_contracts/cairo0/test_contract.cairo
@@ -274,7 +274,9 @@ func invoke_call_chain{syscall_ptr: felt*}(calldata_len: felt, calldata: felt*) 
 
 @external
 func fail() {
-    assert 0 = 1;
+    with_attr error_message("You shall not pass!") {
+        assert 0 = 1;
+    }
     return ();
 }
 

--- a/crates/blockifier/src/execution/stack_trace_test.rs
+++ b/crates/blockifier/src/execution/stack_trace_test.rs
@@ -105,6 +105,7 @@ Unknown location (pc=0:{entry_point_location})
 
 2: Error in the called contract (contract address: {test_contract_address_2_felt:#064x}, class \
          hash: {test_contract_hash:#064x}, selector: {inner_entry_point_selector_felt:#064x}):
+Error message: You shall not pass!
 Error at pc=0:1184:
 Cairo traceback (most recent call last):
 Unknown location (pc=0:1188)
@@ -147,6 +148,10 @@ fn test_trace_callchain_ends_with_regular_call(
     #[case] expected_error: &str,
     #[case] expected_pc_locations: (u16, u16),
 ) {
+    let expected_with_attr_error_msg = match (cairo_version, last_func_name) {
+        (CairoVersion::Cairo0, "fail") => "Error message: You shall not pass!\n".to_string(),
+        _ => String::new(),
+    };
     let chain_info = ChainInfo::create_for_testing();
     let account_contract = FeatureContract::AccountWithoutValidations(cairo_version);
     let test_contract = FeatureContract::TestContract(cairo_version);
@@ -221,7 +226,7 @@ Unknown location (pc=0:{entry_point_location})
 
 2: Error in the called contract (contract address: {contract_address_felt:#064x}, class hash: \
                  {test_contract_hash:#064x}, selector: {invoke_call_chain_selector_felt:#064x}):
-Error at pc=0:{expected_pc0}:
+{expected_with_attr_error_msg}Error at pc=0:{expected_pc0}:
 Cairo traceback (most recent call last):
 Unknown location (pc=0:{call_location})
 Unknown location (pc=0:{expected_pc1})
@@ -272,6 +277,10 @@ fn test_trace_call_chain_with_syscalls(
     #[case] call_type: u8,
     #[case] expected_pcs: (u16, u16, u16, u16),
 ) {
+    let expected_with_attr_error_msg = match (cairo_version, last_func_name) {
+        (CairoVersion::Cairo0, "fail") => "Error message: You shall not pass!\n".to_string(),
+        _ => String::new(),
+    };
     let chain_info = ChainInfo::create_for_testing();
     let account_contract = FeatureContract::AccountWithoutValidations(cairo_version);
     let test_contract = FeatureContract::TestContract(cairo_version);
@@ -374,7 +383,7 @@ Unknown location (pc=0:{call_location})
 Unknown location (pc=0:{expected_pc1})
 
 3: {last_call_preamble}:
-Error at pc=0:{expected_pc2}:
+{expected_with_attr_error_msg}Error at pc=0:{expected_pc2}:
 Cairo traceback (most recent call last):
 Unknown location (pc=0:{expected_pc3})
 


### PR DESCRIPTION
restores the ability of blockifier to display CairoZero with_attr error messages in the stack trace.